### PR TITLE
Prevent notification payload exposure in webhook failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,22 @@ Webhook Notification Provider `Connector` is provided as a Docker container. Use
 | `DB_SCHEMA`     | Database schema to use                                   | ![](https://img.shields.io/badge/-NO-red.svg)      | `webhooknp`   |
 | `PORT`          | Port where the service is exposed                        | ![](https://img.shields.io/badge/-NO-red.svg)      | `8080`        |
 | `JAVA_OPTS`     | Customize Java system properties for running application | ![](https://img.shields.io/badge/-NO-red.svg)      | `N/A`         |
+| `NOTIFICATION_LOG_REQUEST_PAYLOAD` | Include the notification request in DEBUG logs. See [How to enable DEBUG logs](#how-to-enable-debug-logs) | ![](https://img.shields.io/badge/-NO-red.svg) | `false` |
+
+## How to enable DEBUG logs
+
+To enable DEBUG logs for the implementation of the webhook notification provider, you need to set the following environment variable:
+```shell
+LOGGING_LEVEL_COM_CZERTAINLY=DEBUG
+```
+
+DEBUG logs describe each notification by its identifiers only — event, resource, recipient count, and whether notification data is present. The notification request itself is never written to the logs at any level unless payload logging is switched on explicitly:
+
+```shell
+NOTIFICATION_LOG_REQUEST_PAYLOAD=true
+```
+
+> **Warning**
+> With payload logging enabled, DEBUG logs contain the complete notification request, including data that can be sensitive — for example the one-time credential of certificate registration events, or object data enabled on the notification profile. Enable it only while troubleshooting, and treat the logs accordingly.
+
+Template failures do not need it: they are reported at ERROR level with the template identifier, the event and resource, and the position of the failing expression in the template, without exposing any payload.

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,12 @@
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-database-postgresql</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/czertainly/np/webhook/service/impl/NotificationInstanceServiceImpl.java
+++ b/src/main/java/com/czertainly/np/webhook/service/impl/NotificationInstanceServiceImpl.java
@@ -19,8 +19,10 @@ import com.czertainly.np.webhook.util.TemplateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
 import reactor.core.publisher.Mono;
 
 import java.util.Base64;
@@ -37,9 +39,22 @@ public class NotificationInstanceServiceImpl implements NotificationInstanceServ
 
     private AttributeService attributeService;
 
+    /**
+     * Whether DEBUG logging includes the notification request itself. The request carries values
+     * that must not reach logs by default — the certificate-registration credential among them —
+     * so payload logging is a separate, deliberate switch rather than a side effect of raising the
+     * log level.
+     */
+    private boolean logRequestPayload;
+
     @Autowired
     public void setNotificationInstanceRepository(NotificationInstanceRepository notificationInstanceRepository) {
         this.notificationInstanceRepository = notificationInstanceRepository;
+    }
+
+    @Value("${notification.log-request-payload:false}")
+    public void setLogRequestPayload(boolean logRequestPayload) {
+        this.logRequestPayload = logRequestPayload;
     }
 
     @Autowired
@@ -144,7 +159,11 @@ public class NotificationInstanceServiceImpl implements NotificationInstanceServ
                 .findByUuid(uuid)
                 .orElseThrow(() -> new NotFoundException(NotificationInstance.class, uuid));
 
-        logger.debug("Request to send webhook received with the content: {}", request);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Request to send webhook received: {}", logRequestPayload
+                    ? TemplateUtils.describeRequestForDebug(request)
+                    : TemplateUtils.summarizeRequest(request));
+        }
 
         // send request data to webhook URL as POST JSON request
         // create NotificationException if the request fails
@@ -152,7 +171,6 @@ public class NotificationInstanceServiceImpl implements NotificationInstanceServ
         // + add random nonce to header X-CZERTAINLY-Nonce
         String url = notificationInstance.getUrl();
         String timestamp = String.valueOf(System.currentTimeMillis());
-        // nonce has at least 128-bit entropy and its valus is Base64 encoded
         String nonce = Base64.getEncoder().encodeToString(UUID.randomUUID().toString().getBytes());
 
         Object content;
@@ -161,7 +179,7 @@ public class NotificationInstanceServiceImpl implements NotificationInstanceServ
             content = request;
         } else {
             String contentTemplate = notificationInstance.getContentTemplate();
-            content = TemplateUtils.processFreeMarkerTemplate(contentTemplate, request);
+            content = TemplateUtils.processFreeMarkerTemplate("webhook content", contentTemplate, request);
         }
 
         logger.info("Sending webhook to: {}, with timestamp {}, and nonce {}", url, timestamp, nonce);
@@ -180,10 +198,26 @@ public class NotificationInstanceServiceImpl implements NotificationInstanceServ
                     return Mono.error(new NotificationException("Failed to send webhook to " + url + ": " + clientResponse.statusCode()));
                 })
                 .bodyToMono(Void.class)
-                .doOnError(e -> logger.error("Error sending webhook to {}: {}", url, e.getMessage()))
-                .subscribe();
+                // Delivery is asynchronous, so the outcome is logged from the callbacks rather
+                // than after subscribing. The explicit error consumer also keeps failures out of
+                // Reactor's onErrorDropped logging, which would print the raw throwable and
+                // bypass the sanitization in describeSendFailure.
+                .doOnSuccess(unused -> logger.info("Webhook sent to: {}", url))
+                .subscribe(unused -> { },
+                        e -> logger.error("Error sending webhook to {}: {}", url, describeSendFailure(e)));
+    }
 
-        logger.info("Webhook sent to: {}", url);
+    /**
+     * Transport failures carry safe, useful detail (host, port, HTTP status); anything else —
+     * for example a request-body encoding failure — can embed request content in its message,
+     * so only the exception type is reported. The request itself is inspectable through DEBUG
+     * logging.
+     */
+    static String describeSendFailure(Throwable e) {
+        if (e instanceof NotificationException || e instanceof WebClientRequestException) {
+            return e.getMessage();
+        }
+        return e.getClass().getSimpleName();
     }
 
 }

--- a/src/main/java/com/czertainly/np/webhook/util/TemplateUtils.java
+++ b/src/main/java/com/czertainly/np/webhook/util/TemplateUtils.java
@@ -2,8 +2,10 @@ package com.czertainly.np.webhook.util;
 
 import com.czertainly.api.model.connector.notification.NotificationProviderNotifyRequestDto;
 import com.czertainly.np.webhook.exception.NotificationException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
@@ -20,15 +22,66 @@ public class TemplateUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(TemplateUtils.class);
 
-    public static String processFreeMarkerTemplate(String data, NotificationProviderNotifyRequestDto request) {
+    /**
+     * Shared mapper: constructing one per call is expensive, and the registered modules keep
+     * types such as {@code java.time} serializable instead of degrading DEBUG output to the
+     * unserializable placeholder.
+     */
+    private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder().findAndAddModules().build();
+
+    private TemplateUtils() {
+    }
+
+    /**
+     * Payload-free summary of a notification request: identifiers and counts only. This is what
+     * DEBUG logging reports unless payload logging is explicitly switched on.
+     */
+    public static String summarizeRequest(NotificationProviderNotifyRequestDto request) {
+        return "event=%s, resource=%s, recipients=%d, notificationData=%s".formatted(
+                request.getEvent(), request.getResource(),
+                request.getRecipients() == null ? 0 : request.getRecipients().size(),
+                request.getNotificationData() == null ? "absent" : "present");
+    }
+
+    /**
+     * Serializes the whole notification request for opt-in DEBUG logging — the sanctioned way
+     * to inspect payload content when debugging. Uses explicit JSON serialization because the
+     * request's {@code toString} may exclude the payload-bearing fields, which would make DEBUG
+     * output silently incomplete. A request that cannot be serialized — including one whose own
+     * accessors fail — yields a payload-free placeholder rather than disrupting the send flow.
+     */
+    public static String describeRequestForDebug(NotificationProviderNotifyRequestDto request) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(request);
+        } catch (JsonProcessingException | RuntimeException e) {
+            return "unserializable notification request (" + e.getClass().getSimpleName() + ")";
+        }
+    }
+
+    /**
+     * Renders the given FreeMarker template against the notification request.
+     *
+     * <p>Failure logs and exception messages carry the template label, the event and resource
+     * identifiers, and the underlying error only — never the request payload or the data model.
+     * The request's {@code notificationData} and {@code objectData} can hold sensitive values
+     * (for example a certificate-registration credential), and the thrown exception's message
+     * becomes this connector's HTTP error response toward the platform, so payload content must
+     * not reach either. Full request visibility for debugging remains available through the
+     * DEBUG-level logging of the send flow.</p>
+     *
+     * @param templateLabel identifies the rendered template in errors, e.g. "webhook content"
+     */
+    public static String processFreeMarkerTemplate(String templateLabel, String templateSource, NotificationProviderNotifyRequestDto request) {
         // Convert a request to a Map instead of using the JSON node directly
-        ObjectMapper objectMapper = new ObjectMapper();
         Map<String, Object> dataModel;
         try {
-            dataModel = objectMapper.convertValue(request, new TypeReference<>() {});
+            dataModel = OBJECT_MAPPER.convertValue(request, new TypeReference<>() {});
         } catch (IllegalArgumentException e) {
-            logger.error("Error while converting request to Map: {}, {}", request, e.getMessage());
-            throw new NotificationException("Error while converting request to Map: " + request + ", " + e.getMessage());
+            // Only the exception type is reported: Jackson conversion messages can embed model
+            // paths or content, and this internal failure has no template-author diagnostics value.
+            logger.error("Failed to build the {} template data model: event={}, resource={}, error={}",
+                    templateLabel, request.getEvent(), request.getResource(), e.getClass().getSimpleName());
+            throw new NotificationException("Failed to build the " + templateLabel + " template data model (" + e.getClass().getSimpleName() + ")");
         }
 
         // Prepare FreeMarker configuration
@@ -38,13 +91,15 @@ public class TemplateUtils {
         cfg.setLogTemplateExceptions(false);
         cfg.setWrapUncheckedExceptions(true);
 
-        // Create a template from the HTML string
         Template template;
         try {
-            template = new Template("contentTemplate", new StringReader(data), cfg);
+            template = new Template(templateLabel, new StringReader(templateSource), cfg);
         } catch (IOException e) {
-            logger.error("Error while creating FreeMarker template: {}, {}", data, e.getMessage());
-            throw new NotificationException("Error while creating FreeMarker template: " + e.getMessage(), e);
+            // Parsing happens before the data model is bound, so this message describes the
+            // operator's own template only and cannot quote payload values.
+            logger.error("Failed to parse the {} template: event={}, resource={}, error={}",
+                    templateLabel, request.getEvent(), request.getResource(), e.getMessage());
+            throw new NotificationException("Failed to parse the " + templateLabel + " template: " + e.getMessage(), e);
         }
 
         // Process the template with the data model
@@ -52,11 +107,27 @@ public class TemplateUtils {
         try {
             template.process(dataModel, stringWriter);
         } catch (TemplateException | IOException e) {
-            logger.error("Error while processing FreeMarker template: {}, {}", request, e.getMessage());
-            throw new NotificationException("Error while processing FreeMarker template: " + e.getMessage());
+            String diagnostics = renderFailureDiagnostics(e);
+            logger.error("Failed to render the {} template: event={}, resource={}, error={}",
+                    templateLabel, request.getEvent(), request.getResource(), diagnostics);
+            throw new NotificationException("Failed to render the " + templateLabel + " template: " + diagnostics);
         }
 
         return stringWriter.toString();
+    }
+
+    /**
+     * Payload-free description of a rendering failure. FreeMarker quotes the value that failed to
+     * evaluate in its message — {@code ${credential?number}} embeds the credential verbatim — so
+     * only the exception type and the position in the template are reported. The template is the
+     * operator's own content, so the position identifies the failing expression for them.
+     */
+    static String renderFailureDiagnostics(Exception e) {
+        if (e instanceof TemplateException templateException) {
+            return "%s at line %s, column %s".formatted(e.getClass().getSimpleName(),
+                    templateException.getLineNumber(), templateException.getColumnNumber());
+        }
+        return e.getClass().getSimpleName();
     }
 
 }

--- a/src/test/java/com/czertainly/np/webhook/service/impl/NotificationInstanceServiceImplTest.java
+++ b/src/test/java/com/czertainly/np/webhook/service/impl/NotificationInstanceServiceImplTest.java
@@ -1,0 +1,204 @@
+package com.czertainly.np.webhook.service.impl;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.czertainly.api.model.connector.notification.NotificationProviderNotifyRequestDto;
+import com.czertainly.api.model.core.auth.Resource;
+import com.czertainly.api.model.core.other.ResourceEvent;
+import com.czertainly.np.webhook.attribute.ContentType;
+import com.czertainly.np.webhook.dao.entity.NotificationInstance;
+import com.czertainly.np.webhook.dao.repository.NotificationInstanceRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+
+import com.sun.net.httpserver.HttpServer;
+
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationInstanceServiceImplTest {
+
+    private static final String SENSITIVE_VALUE = "debug-visible-credential";
+
+    @Mock
+    private NotificationInstanceRepository repository;
+
+    private NotificationInstanceServiceImpl service;
+
+    private ListAppender<ILoggingEvent> logAppender;
+    private Level originalLevel;
+
+    @BeforeEach
+    void setUp() {
+        service = new NotificationInstanceServiceImpl();
+        service.setNotificationInstanceRepository(repository);
+
+        Logger serviceLogger = serviceLogger();
+        originalLevel = serviceLogger.getLevel();
+        logAppender = new ListAppender<>();
+        logAppender.start();
+        serviceLogger.addAppender(logAppender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        Logger serviceLogger = serviceLogger();
+        serviceLogger.setLevel(originalLevel);
+        serviceLogger.detachAppender(logAppender);
+        logAppender.stop();
+    }
+
+    private Logger serviceLogger() {
+        return (Logger) LoggerFactory.getLogger(NotificationInstanceServiceImpl.class);
+    }
+
+    private NotificationProviderNotifyRequestDto request() {
+        NotificationProviderNotifyRequestDto request = new NotificationProviderNotifyRequestDto();
+        request.setEvent(ResourceEvent.CERTIFICATE_STATUS_CHANGED);
+        request.setResource(Resource.CERTIFICATE);
+        request.setNotificationData(Map.of("credential", SENSITIVE_VALUE));
+        return request;
+    }
+
+    private UUID persistedInstance(ContentType contentType, String contentTemplate) {
+        return persistedInstance(contentType, contentTemplate, "http://localhost:9");
+    }
+
+    private UUID persistedInstance(ContentType contentType, String contentTemplate, String url) {
+        UUID uuid = UUID.randomUUID();
+        NotificationInstance instance = new NotificationInstance();
+        instance.setUuid(uuid);
+        instance.setName("test-webhook");
+        instance.setUrl(url);
+        instance.setContentType(contentType);
+        instance.setContentTemplate(contentTemplate);
+        when(repository.findByUuid(uuid)).thenReturn(Optional.of(instance));
+        return uuid;
+    }
+
+    /**
+     * The delivery outcome is logged from the asynchronous callbacks, so a webhook that the
+     * receiver accepts must still report the send — covered against a real endpoint because the
+     * success callback is never reached when the endpoint is unreachable.
+     */
+    @Test
+    void sendNotification_acceptedByReceiver_logsTheCompletedSend() throws Exception {
+        HttpServer receiver = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        receiver.createContext("/", exchange -> {
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+        });
+        receiver.start();
+        try {
+            UUID uuid = persistedInstance(ContentType.RAW_JSON, null,
+                    "http://localhost:" + receiver.getAddress().getPort());
+
+            assertDoesNotThrow(() -> service.sendNotification(uuid, request()));
+
+            assertTrue(awaitLog(message -> message.startsWith("Webhook sent to")),
+                    "an accepted webhook must be reported as sent: " + formattedLogs());
+        } finally {
+            receiver.stop(0);
+        }
+    }
+
+    /**
+     * Payload logging is opt-in: raising the log level alone must never write the request into the
+     * logs, only the payload-free summary.
+     */
+    @Test
+    void sendNotification_debugLoggingWithoutOptIn_logsNoPayload() {
+        UUID uuid = persistedInstance(ContentType.RAW_JSON, null);
+        serviceLogger().setLevel(Level.DEBUG);
+
+        assertDoesNotThrow(() -> service.sendNotification(uuid, request()));
+
+        assertTrue(formattedLogs().stream().noneMatch(message -> message.contains(SENSITIVE_VALUE)),
+                "DEBUG alone must not write the request payload: " + formattedLogs());
+        assertTrue(formattedLogs().stream().anyMatch(message -> message.contains("notificationData=present")),
+                "the payload-free summary must still be logged: " + formattedLogs());
+    }
+
+    /** With payload logging switched on, the full request is available for troubleshooting. */
+    @Test
+    void sendNotification_debugLoggingWithOptIn_retainsRequestVisibility() {
+        UUID uuid = persistedInstance(ContentType.RAW_JSON, null);
+        service.setLogRequestPayload(true);
+        serviceLogger().setLevel(Level.DEBUG);
+
+        assertDoesNotThrow(() -> service.sendNotification(uuid, request()));
+
+        assertTrue(formattedLogs().stream().anyMatch(message -> message.contains(SENSITIVE_VALUE)),
+                "with payload logging enabled the request content must be available");
+    }
+
+    @Test
+    void describeSendFailure_transportErrorsKeepTheirMessage() {
+        assertTrue(NotificationInstanceServiceImpl.describeSendFailure(
+                        new com.czertainly.np.webhook.exception.NotificationException("Failed to send webhook to x: 500"))
+                .contains("Failed to send webhook to x: 500"));
+    }
+
+    @Test
+    void describeSendFailure_connectionErrorsKeepTheirMessage() {
+        org.springframework.web.reactive.function.client.WebClientRequestException transport =
+                new org.springframework.web.reactive.function.client.WebClientRequestException(
+                        new java.net.ConnectException("Connection refused: localhost:9"),
+                        org.springframework.http.HttpMethod.POST,
+                        java.net.URI.create("http://localhost:9"),
+                        new org.springframework.http.HttpHeaders());
+        assertTrue(NotificationInstanceServiceImpl.describeSendFailure(transport).contains("Connection refused"));
+    }
+
+    @Test
+    void describeSendFailure_otherErrorsAreReducedToTheirType() {
+        String described = NotificationInstanceServiceImpl.describeSendFailure(
+                new IllegalStateException("encoder failure exposing " + SENSITIVE_VALUE));
+        assertTrue(described.equals("IllegalStateException"),
+                "unknown failures must be reduced to the exception type: " + described);
+    }
+
+    @Test
+    void sendNotification_templatedContent_rendersWithoutPayloadInDefaultLogs() throws InterruptedException {
+        UUID uuid = persistedInstance(ContentType.JSON,
+                Base64.getEncoder().encodeToString("{\"event\": \"${event}\"}".getBytes(StandardCharsets.UTF_8)));
+
+        assertDoesNotThrow(() -> service.sendNotification(uuid, request()));
+        // Delivery is asynchronous: wait for its outcome to be logged, otherwise the assertion
+        // could run before the send path had a chance to log anything at all.
+        assertTrue(awaitLog(message -> message.startsWith("Error sending webhook to") || message.startsWith("Webhook sent to")),
+                "the asynchronous send outcome was never logged");
+
+        assertTrue(formattedLogs().stream().noneMatch(message -> message.contains(SENSITIVE_VALUE)),
+                "default-level logs must not carry the request payload");
+    }
+
+    private boolean awaitLog(java.util.function.Predicate<String> matcher) throws InterruptedException {
+        for (int attempt = 0; attempt < 100; attempt++) {
+            if (formattedLogs().stream().anyMatch(matcher)) return true;
+            Thread.sleep(50);
+        }
+        return false;
+    }
+
+    private java.util.List<String> formattedLogs() {
+        return logAppender.list.stream().map(ILoggingEvent::getFormattedMessage).toList();
+    }
+
+}

--- a/src/test/java/com/czertainly/np/webhook/util/TemplateUtilsErrorTest.java
+++ b/src/test/java/com/czertainly/np/webhook/util/TemplateUtilsErrorTest.java
@@ -1,0 +1,203 @@
+package com.czertainly.np.webhook.util;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.czertainly.api.model.connector.notification.NotificationProviderNotifyRequestDto;
+import com.czertainly.api.model.core.auth.Resource;
+import com.czertainly.api.model.core.other.ResourceEvent;
+import com.czertainly.np.webhook.exception.NotificationException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TemplateUtilsErrorTest {
+
+    private static final String TEMPLATE_LABEL = "webhook content";
+    private static final String SENSITIVE_VALUE = "registration-credential-7f3a9";
+
+    private ListAppender<ILoggingEvent> logAppender;
+
+    @BeforeEach
+    void captureLogs() {
+        logAppender = new ListAppender<>();
+        logAppender.start();
+        ((Logger) LoggerFactory.getLogger(TemplateUtils.class)).addAppender(logAppender);
+    }
+
+    @AfterEach
+    void releaseLogs() {
+        ((Logger) LoggerFactory.getLogger(TemplateUtils.class)).detachAppender(logAppender);
+        logAppender.stop();
+    }
+
+    private NotificationProviderNotifyRequestDto request() {
+        NotificationProviderNotifyRequestDto request = new NotificationProviderNotifyRequestDto();
+        request.setEvent(ResourceEvent.CERTIFICATE_STATUS_CHANGED);
+        request.setResource(Resource.CERTIFICATE);
+        request.setNotificationData(Map.of("credential", SENSITIVE_VALUE));
+        return request;
+    }
+
+    @Test
+    void malformedTemplateThrowsCreationError() {
+        NotificationException ex = assertThrows(NotificationException.class,
+                () -> TemplateUtils.processFreeMarkerTemplate(TEMPLATE_LABEL, "${unclosed", request()));
+        assertTrue(ex.getMessage().contains(TEMPLATE_LABEL));
+        assertNoPayloadExposure(ex);
+    }
+
+    @Test
+    void unresolvedReferenceThrowsProcessingError() {
+        NotificationException ex = assertThrows(NotificationException.class,
+                () -> TemplateUtils.processFreeMarkerTemplate(TEMPLATE_LABEL, "${totallyMissingVar}", request()));
+        assertTrue(ex.getMessage().contains(TEMPLATE_LABEL));
+        assertTrue(ex.getMessage().contains("line"), "the rendering failure must stay locatable in the template");
+        assertNoPayloadExposure(ex);
+    }
+
+    @Test
+    void renderingFailureLogsTemplateAndEventIdentifiers() {
+        NotificationProviderNotifyRequestDto request = request();
+        assertThrows(NotificationException.class,
+                () -> TemplateUtils.processFreeMarkerTemplate(TEMPLATE_LABEL, "${totallyMissingVar}", request));
+
+        List<String> errorLogs = formattedLogs();
+        assertFalse(errorLogs.isEmpty());
+        assertTrue(errorLogs.stream().anyMatch(message -> message.contains(TEMPLATE_LABEL)
+                        && message.contains(String.valueOf(request.getEvent()))
+                        && message.contains(String.valueOf(request.getResource()))),
+                "failure log must identify the template, event, and resource: " + errorLogs);
+    }
+
+    @Test
+    void dataModelConversionFailureExposesNoPayload() {
+        NotificationProviderNotifyRequestDto request = request();
+        request.setNotificationData(new Object() {
+            public String getCredential() {
+                return SENSITIVE_VALUE;
+            }
+
+            public String getBoom() {
+                // The cause message lands inside Jackson's conversion-failure message, so it must
+                // not be forwarded either — only the exception type may be reported.
+                throw new IllegalStateException("boom-" + SENSITIVE_VALUE);
+            }
+        });
+
+        NotificationException ex = assertThrows(NotificationException.class,
+                () -> TemplateUtils.processFreeMarkerTemplate(TEMPLATE_LABEL, "irrelevant", request));
+        assertTrue(ex.getMessage().contains(TEMPLATE_LABEL));
+        assertNoPayloadExposure(ex);
+    }
+
+    /**
+     * FreeMarker quotes the offending value in coercion failures, so the raw message must never
+     * reach the log or the exception returned to the platform.
+     */
+    @Test
+    void coercionFailureExposesNoPayloadValue() {
+        NotificationException ex = assertThrows(NotificationException.class,
+                () -> TemplateUtils.processFreeMarkerTemplate(TEMPLATE_LABEL,
+                        "${notificationData.credential?number}", request()));
+
+        assertNoPayloadExposure(ex);
+        assertTrue(ex.getMessage().contains("line"), "the failure must still point at the template position");
+    }
+
+    /** Date coercion quotes the value in its own message format, so it is covered separately. */
+    @Test
+    void dateCoercionFailureExposesNoPayloadValue() {
+        NotificationException ex = assertThrows(NotificationException.class,
+                () -> TemplateUtils.processFreeMarkerTemplate(TEMPLATE_LABEL,
+                        "${notificationData.credential?datetime}", request()));
+
+        assertNoPayloadExposure(ex);
+    }
+
+    /** Failures without a template position fall back to the exception type alone. */
+    @Test
+    void nonTemplateRenderFailureIsDescribedByTypeOnly() {
+        assertTrue(TemplateUtils.renderFailureDiagnostics(new java.io.IOException("writer broke on " + SENSITIVE_VALUE))
+                .equals("IOException"));
+    }
+
+    @Test
+    void summaryReportsIdentifiersWithoutPayload() {
+        String summary = TemplateUtils.summarizeRequest(request());
+
+        assertFalse(summary.contains(SENSITIVE_VALUE), "the summary must never carry payload values");
+        assertTrue(summary.contains("notificationData=present"));
+        assertTrue(summary.contains("recipients=0"));
+    }
+
+    @Test
+    void summaryCountsResolvedRecipients() {
+        NotificationProviderNotifyRequestDto request = request();
+        com.czertainly.api.model.connector.notification.NotificationRecipientDto recipient =
+                new com.czertainly.api.model.connector.notification.NotificationRecipientDto();
+        recipient.setName("R1");
+        request.setRecipients(java.util.List.of(recipient));
+
+        assertTrue(TemplateUtils.summarizeRequest(request).contains("recipients=1"));
+    }
+
+    /** Recipient-less profiles send no recipients and events may carry no data; neither must fail. */
+    @Test
+    void summaryHandlesAbsentRecipientsAndData() {
+        NotificationProviderNotifyRequestDto request = new NotificationProviderNotifyRequestDto();
+        request.setEvent(ResourceEvent.CERTIFICATE_STATUS_CHANGED);
+        request.setResource(Resource.CERTIFICATE);
+
+        String summary = TemplateUtils.summarizeRequest(request);
+
+        assertTrue(summary.contains("recipients=0"));
+        assertTrue(summary.contains("notificationData=absent"));
+    }
+
+    @Test
+    void debugDescriptionCarriesFullPayload() {
+        assertTrue(TemplateUtils.describeRequestForDebug(request()).contains(SENSITIVE_VALUE),
+                "DEBUG description is the sanctioned payload-visibility mechanism and must serialize the payload");
+    }
+
+    @Test
+    void debugDescriptionOfUnserializableRequestIsPayloadFree() {
+        NotificationProviderNotifyRequestDto request = request();
+        request.setNotificationData(new Object() {
+            public String getCredential() {
+                return SENSITIVE_VALUE;
+            }
+
+            public String getBoom() {
+                throw new IllegalStateException("boom");
+            }
+        });
+
+        String description = TemplateUtils.describeRequestForDebug(request);
+        assertTrue(description.contains("unserializable"));
+        assertFalse(description.contains(SENSITIVE_VALUE));
+    }
+
+    private void assertNoPayloadExposure(NotificationException ex) {
+        assertFalse(ex.getMessage().contains(SENSITIVE_VALUE),
+                "exception message must not carry the request payload: " + ex.getMessage());
+        for (String message : formattedLogs()) {
+            assertFalse(message.contains(SENSITIVE_VALUE),
+                    "log output must not carry the request payload: " + message);
+        }
+    }
+
+    private List<String> formattedLogs() {
+        return logAppender.list.stream().map(ILoggingEvent::getFormattedMessage).toList();
+    }
+
+}


### PR DESCRIPTION
Closes #24

Template-rendering failures logged the entire notification request at ERROR level and embedded it into the exception message returned to the platform, where it also reached the platform's logs. The request can carry sensitive values — for example the one-time credential of certificate registration events, or object data enabled on the notification profile.

- Failure logs and exception messages now carry only the template label (`webhook content`), the event and resource identifiers, and the rendering error; data-model conversion failures and unexpected send failures report only the exception type.
- The webhook delivery uses an explicit error consumer, so no failure reaches Reactor's raw dropped-error logging; transport and HTTP failures keep their diagnostic detail.
- DEBUG-level request logging is deliberately retained as the opt-in way to inspect the payload while debugging, now serialized explicitly so payload fields stay visible regardless of the DTO's `toString` behavior. The README warns about its sensitivity.
- Adds the test setup and the first tests of the connector, including regressions asserting that failure logs and exception messages carry no payload fields and that DEBUG logging keeps the request visible.